### PR TITLE
grafana must run on leader

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -22,6 +22,7 @@
 
 import sys
 import json
+import os
 
 config = {"host": "", "http2https": True, "lets_encrypt": False}
 
@@ -31,5 +32,8 @@ try:
         config = json.loads(fp.read())
 except:
     pass
+
+# grafana must run on leader
+config['running_on_leader'] = os.path.exists('/etc/nethserver/logcli.env')
 
 json.dump(config, fp=sys.stdout)

--- a/imageroot/bin/provision
+++ b/imageroot/bin/provision
@@ -28,8 +28,10 @@ rdb = agent.redis_connect()
 default_instance = rdb.get(f'node/{os.environ["NODE_ID"]}/default_instance/prometheus')  or "prometheus1"
 node_path = rdb.hget(f'module/{default_instance}/environment', 'PROMETHEUS_PATH') or "/prometheus"
 
-# Read loki config from local node
-logcli = agent.read_envfile("/etc/nethserver/logcli.env")
+# Read loki config from local node, only Leader
+path = "/etc/nethserver/logcli.env"
+if os.path.exists(path):
+    logcli = agent.read_envfile(path)
 
 with open('local.yml', 'w') as fp:
     fp.write("apiVersion: 1\n")
@@ -39,13 +41,13 @@ with open('local.yml', 'w') as fp:
     fp.write('    uid: prometheus\n')
     fp.write('    access: proxy\n')
     fp.write(f'    url: http://node/{node_path}\n')
-
-    fp.write('  - name: Local Loki\n')
-    fp.write('    type: loki\n')
-    fp.write('    uid: loki\n')
-    fp.write('    access: proxy\n')
-    fp.write(f'    url: {logcli["LOKI_ADDR"]}\n')
-    fp.write(f'    basicAuth: true\n')
-    fp.write(f'    basicAuthUser: {logcli["LOKI_USERNAME"]}\n')
-    fp.write('    secureJsonData:\n')
-    fp.write(f'      basicAuthPassword: {logcli["LOKI_PASSWORD"]}\n')
+    if os.path.exists(path):
+        fp.write('  - name: Local Loki\n')
+        fp.write('    type: loki\n')
+        fp.write('    uid: loki\n')
+        fp.write('    access: proxy\n')
+        fp.write(f'    url: {logcli["LOKI_ADDR"]}\n')
+        fp.write(f'    basicAuth: true\n')
+        fp.write(f'    basicAuthUser: {logcli["LOKI_USERNAME"]}\n')
+        fp.write('    secureJsonData:\n')
+        fp.write(f'      basicAuthPassword: {logcli["LOKI_PASSWORD"]}\n')

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -29,8 +29,8 @@
     "lets_encrypt": "Let's Encrypt certificate",
     "disabled": "Disabled",
     "enabled": "Enabled",
-    "grafana_must_be_installed_on_leader_node": "This software is supposed to run on the Leader node",
-    "grafana_must_be_removed_from_a_worker_node": "You must remove Grafana or promote to Leader this node"
+    "grafana_must_be_installed_on_leader_node": "Grafana is supposed to run on the leader node",
+    "grafana_must_be_removed_from_a_worker_node": "You should remove Grafana from the worker node and install it to the leader node"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -28,7 +28,9 @@
     "http2https": "Redirect HTTP to HTTPS",
     "lets_encrypt": "Let's Encrypt certificate",
     "disabled": "Disabled",
-    "enabled": "Enabled"
+    "enabled": "Enabled",
+    "grafana_must_be_installed_on_leader_node": "This software is supposed to run on the Leader node",
+    "grafana_must_be_removed_from_a_worker_node": "You must remove Grafana or promote to Leader this node"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -39,7 +39,11 @@
               :label="$t('settings.host')"
               v-model="host"
               :placeholder="$t('settings.host')"
-              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                !running_on_leader
+              "
               :invalid-message="error.host"
               ref="host"
             ></cv-text-input>
@@ -57,7 +61,11 @@
               value="letsEncrypt"
               :label="$t('settings.lets_encrypt')"
               v-model="lets_encrypt"
-              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                !running_on_leader
+              "
               class="mg-bottom"
             >
               <template slot="text-left">{{
@@ -71,7 +79,11 @@
               value="http2https"
               :label="$t('settings.http2https')"
               v-model="http2https"
-              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                !running_on_leader
+              "
               class="mg-bottom"
             >
               <template slot="text-left">{{
@@ -85,7 +97,11 @@
               kind="primary"
               :icon="Save20"
               :loading="loading.configureModule"
-              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                !running_on_leader
+              "
               >{{ $t("settings.save") }}</NsButton
             >
           </cv-form>
@@ -130,7 +146,7 @@ export default {
         configureModule: "",
         host: "",
         http2https: "",
-        lets_encrypt: ""
+        lets_encrypt: "",
       },
     };
   },
@@ -262,7 +278,7 @@ export default {
           data: {
             host: this.host,
             http2https: this.http2https,
-            lets_encrypt: this.lets_encrypt
+            lets_encrypt: this.lets_encrypt,
           },
           extra: {
             title: this.$t("settings.configure_instance", {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -18,12 +18,28 @@
     <cv-row>
       <cv-column>
         <cv-tile light>
-          <cv-form @submit.prevent="configureModule">
+          <cv-skeleton-text
+            v-if="loading.getConfiguration || loading.getDefaults"
+            heading
+            paragraph
+            :line-count="10"
+            width="80%"
+          ></cv-skeleton-text>
+          <cv-form v-else @submit.prevent="configureModule">
+            <template v-if="!running_on_leader">
+              <NsInlineNotification
+                kind="info"
+                :title="$t('settings.grafana_must_be_installed_on_leader_node')"
+                :description="
+                  $t('settings.grafana_must_be_removed_from_a_worker_node')
+                "
+              />
+            </template>
             <cv-text-input
               :label="$t('settings.host')"
               v-model="host"
               :placeholder="$t('settings.host')"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
               :invalid-message="error.host"
               ref="host"
             ></cv-text-input>
@@ -41,7 +57,7 @@
               value="letsEncrypt"
               :label="$t('settings.lets_encrypt')"
               v-model="lets_encrypt"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
               class="mg-bottom"
             >
               <template slot="text-left">{{
@@ -55,7 +71,7 @@
               value="http2https"
               :label="$t('settings.http2https')"
               v-model="http2https"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
               class="mg-bottom"
             >
               <template slot="text-left">{{
@@ -69,7 +85,7 @@
               kind="primary"
               :icon="Save20"
               :loading="loading.configureModule"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || ! running_on_leader"
               >{{ $t("settings.save") }}</NsButton
             >
           </cv-form>
@@ -104,6 +120,7 @@ export default {
       host: "",
       lets_encrypt: false,
       http2https: false,
+      running_on_leader: false,
       loading: {
         getConfiguration: false,
         configureModule: false,
@@ -182,6 +199,7 @@ export default {
       this.host = config.host;
       this.http2https = config.http2https;
       this.lets_encrypt = config.lets_encrypt;
+      this.running_on_leader = config.running_on_leader;
 
       this.focusElement("host");
     },


### PR DESCRIPTION
grafana must run on leader following what the doc stated
https://ns8.nethserver.org/en/latest/metrics.html

We need to display a banner and disabled to configure the module if we are not on the leader  or if the leader has been promoted to another node

![image](https://github.com/NethServer/ns8-grafana/assets/3164851/c687fbac-73bc-4626-b8a2-6ee065751abc)


https://trello.com/c/Uh9YjzQ3/385-prometheus-grafana-p1-cant-install-on-worker-nodes