### PR TITLE
Discover prometheus and loki from redis

### DIFF
--- a/imageroot/bin/provision
+++ b/imageroot/bin/provision
@@ -28,8 +28,10 @@ rdb = agent.redis_connect()
 default_instance = rdb.get(f'node/{os.environ["NODE_ID"]}/default_instance/prometheus')  or "prometheus1"
 node_path = rdb.hget(f'module/{default_instance}/environment', 'PROMETHEUS_PATH') or "/prometheus"
 
-# Read loki config from local node
-logcli = agent.read_envfile("/etc/nethserver/logcli.env")
+# Read loki config from Redis
+loki = agent.resolve_agent_id("loki@cluster")
+logcli = rdb.hgetall(f'{loki}/environment')
+logcli["LOKI_ADDR"] = 'http://'+logcli["LOKI_ADDR"]+':'+logcli["LOKI_HTTP_PORT"]
 
 with open('local.yml', 'w') as fp:
     fp.write("apiVersion: 1\n")
@@ -46,6 +48,6 @@ with open('local.yml', 'w') as fp:
     fp.write('    access: proxy\n')
     fp.write(f'    url: {logcli["LOKI_ADDR"]}\n')
     fp.write(f'    basicAuth: true\n')
-    fp.write(f'    basicAuthUser: {logcli["LOKI_USERNAME"]}\n')
+    fp.write(f'    basicAuthUser: {logcli["LOKI_API_AUTH_USERNAME"]}\n')
     fp.write('    secureJsonData:\n')
-    fp.write(f'      basicAuthPassword: {logcli["LOKI_PASSWORD"]}\n')
+    fp.write(f'      basicAuthPassword: {logcli["LOKI_API_AUTH_PASSWORD"]}\n')

--- a/imageroot/bin/provision
+++ b/imageroot/bin/provision
@@ -23,6 +23,11 @@
 import os
 import agent
 
+##
+## we need to made a first discover with default value, 
+## probably prometheus will be instally later if not found yet
+##
+
 # Read prometheus config from local node
 rdb = agent.redis_connect(use_replica=True)
 default_instance = agent.resolve_agent_id("prometheus@cluster")  or "module/prometheus1"

--- a/imageroot/bin/provision
+++ b/imageroot/bin/provision
@@ -24,9 +24,9 @@ import os
 import agent
 
 # Read prometheus config from local node
-rdb = agent.redis_connect()
-default_instance = rdb.get(f'node/{os.environ["NODE_ID"]}/default_instance/prometheus')  or "prometheus1"
-node_path = rdb.hget(f'module/{default_instance}/environment', 'PROMETHEUS_PATH') or "/prometheus"
+rdb = agent.redis_connect(use_replica=True)
+default_instance = agent.resolve_agent_id("prometheus@cluster")  or "module/prometheus1"
+node_path = rdb.hget(f'{default_instance}/environment', 'PROMETHEUS_PATH') or "/prometheus"
 
 # Read loki config from Redis
 loki = agent.resolve_agent_id("loki@cluster")


### PR DESCRIPTION
Previously based on logcli.env we can discover settings by reading the redis replica at the service start 

grafana must run on leader following what the doc stated
https://ns8.nethserver.org/en/latest/metrics.html this assumption is probably wrong but it came from /etc/nethserver/logvli.env only available on the first leader

https://trello.com/c/Uh9YjzQ3/385-prometheus-grafana-p1-cant-install-on-worker-nodes


we need to made a first discover with default value, probably prometheus could be instally later