### PR TITLE
Update hostname format validation

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -30,7 +30,8 @@
         "host": {
             "type": "string",
             "description": "Host name for the wiki, like 'wiki.nethserver.org'",
-            "format": "idn-hostname"
+            "format": "hostname",
+            "pattern": "\\."
         },
         "lets_encrypt": {
             "type": "boolean",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -28,7 +28,9 @@
     "http2https": "Redirect HTTP to HTTPS",
     "lets_encrypt": "Let's Encrypt certificate",
     "disabled": "Disabled",
-    "enabled": "Enabled"
+    "enabled": "Enabled",
+    "host_pattern": "Must be a valid fully qualified domain name",
+    "host_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request updates the hostname format validation in the `validate-input.json` file. The `format` property is changed from `idn-hostname` to `hostname` and a new `pattern` property is added to enforce a fully qualified domain name format. Additionally, the translation messages for the `host_pattern` and `host_format` are updated in the `translation.json` file.

https://github.com/NethServer/dev/issues/6853