### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.grafana.org/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/metrics.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-grafana"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `ui/public/metadata.json` file to point to the NethServer NS8 metrics documentation.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL15-R15): Updated the `documentation_url` field to "https://docs.nethserver.org/projects/ns8/en/latest/metrics.html" to reflect the correct documentation for NethServer NS8.


https://github.com/NethServer/dev/issues/7399