### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/grafana.service
+++ b/imageroot/systemd/user/grafana.service
@@ -7,8 +7,8 @@ Description=Grafana server
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/grafana.pid %t/grafana.ctr-id
 ExecStartPre=runagent provision
@@ -21,9 +21,9 @@ ExecStart=/usr/bin/podman run \
     --publish=127.0.0.1:${TCP_PORT}:3000 \
     --network=slirp4netns:allow_host_loopback=true --add-host=node:10.0.2.2 \
     --volume=grafana-data:/var/lib/grafana:z \
-    --volume=%S/state/local.yml:/etc/grafana/provisioning/datasources/local.yml:z \
-    --volume=%S/etc/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z \
-    --volume=%S/etc/dashboards/:/etc/grafana/dashboards:z \
+    --volume=%E/state/local.yml:/etc/grafana/provisioning/datasources/local.yml:z \
+    --volume=%E/etc/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z \
+    --volume=%E/etc/dashboards/:/etc/grafana/dashboards:z \
     ${GRAFANA_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/grafana.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/grafana.ctr-id


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host